### PR TITLE
Commit some initial aliases in order to start laying groundwork for this naming shift.

### DIFF
--- a/src/opentelemetry-api.cr
+++ b/src/opentelemetry-api.cr
@@ -90,6 +90,16 @@ module OpenTelemetry
     provider
   end
 
+  # Alias. The spec uses `TracerProvider`s, which manage `Tracer`s,
+  # but which have internal methods and entities like `trace_id` and `TraceState`
+  # and `TraceFlags`. Then this library was initially written, I opted for uniformly
+  # consistent naming, but that violates the spec. Future versions will move towards
+  # deprecating the uniform naming, in places where that naming violates the spec.
+  # This is here to start preparing for that transition.
+  def self.tracer_provider
+    trace_provider
+  end
+
   def self.trace_provider(&block : TraceProvider::Configuration::Factory ->)
     self.provider = TraceProvider.new do |cfg|
       block.call(cfg)
@@ -98,6 +108,16 @@ module OpenTelemetry
     provider.merge_configuration(@@config)
 
     provider
+  end
+
+  # Alias. The spec uses `TracerProvider`s, which manage `Tracer`s,
+  # but which have internal methods and entities like `trace_id` and `TraceState`
+  # and `TraceFlags`. Then this library was initially written, I opted for uniformly
+  # consistent naming, but that violates the spec. Future versions will move towards
+  # deprecating the uniform naming, in places where that naming violates the spec.
+  # This is here to start preparing for that transition.
+  def self.tracer_provider(&block : TraceProvider::Configuration::Factory ->)
+    self.trace_provider(&block)
   end
 
   def self.trace_provider(
@@ -114,6 +134,23 @@ module OpenTelemetry
     provider
   end
 
+  # Alias. The spec uses `TracerProvider`s, which manage `Tracer`s,
+  # but which have internal methods and entities like `trace_id` and `TraceState`
+  # and `TraceFlags`. Then this library was initially written, I opted for uniformly
+  # consistent naming, but that violates the spec. Future versions will move towards
+  # deprecating the uniform naming, in places where that naming violates the spec.
+  # This is here to start preparing for that transition.
+  def self.tracer_provider(
+    service_name : String = ENV["OTEL_SERVICE_NAME"]? || "",
+    service_version : String = "",
+    exporter = nil
+  )
+    self.trace_provider(
+      service_name: service_name,
+      service_version: service_version,
+      exporter: exporter)
+  end
+
   def self.current_span
     Fiber.current.current_span
   end
@@ -125,11 +162,34 @@ module OpenTelemetry
     r
   end
 
+  # Alias. The spec uses `TracerProvider`s, which manage `Tracer`s,
+  # but which have internal methods and entities like `trace_id` and `TraceState`
+  # and `TraceFlags`. Then this library was initially written, I opted for uniformly
+  # consistent naming, but that violates the spec. Future versions will move towards
+  # deprecating the uniform naming, in places where that naming violates the spec.
+  # This is here to start preparing for that transition.
+  def self.tracer
+    trace
+  end
+
   def self.trace
     trace = self.trace
     yield trace
 
     trace
+  end
+
+  # Alias. The spec uses `TracerProvider`s, which manage `Tracer`s,
+  # but which have internal methods and entities like `trace_id` and `TraceState`
+  # and `TraceFlags`. Then this library was initially written, I opted for uniformly
+  # consistent naming, but that violates the spec. Future versions will move towards
+  # deprecating the uniform naming, in places where that naming violates the spec.
+  # This is here to start preparing for that transition.
+  def self.tracer
+    tracer = self.tracer
+    yield tracer
+
+    tracer
   end
 
   def self.instrumentation_scope

--- a/src/opentelemetry-api/trace.cr
+++ b/src/opentelemetry-api/trace.cr
@@ -267,4 +267,12 @@ module OpenTelemetry
       end
     end
   end
+
+  # Alias. The spec uses `TracerProvider`s, which manage `Tracer`s,
+  # but which have internal methods and entities like `trace_id` and `TraceState`
+  # and `TraceFlags`. Then this library was initially written, I opted for uniformly
+  # consistent naming, but that violates the spec. Future versions will move towards
+  # deprecating the uniform naming, in places where that naming violates the spec.
+  # This is here to start preparing for that transition.
+  alias Tracer = Trace
 end

--- a/src/opentelemetry-api/trace_provider.cr
+++ b/src/opentelemetry-api/trace_provider.cr
@@ -4,6 +4,7 @@ require "./trace"
 module OpenTelemetry
   # A TraceProvider encapsulates a set of tracing configuration, and provides an interface for creating Trace instances.
   class TraceProvider < Provider
+    # Create a new trace, initializing it with the provided parameters.
     def trace(
       service_name = nil,
       service_version = nil,
@@ -22,6 +23,24 @@ module OpenTelemetry
       new_trace
     end
 
+    # Alias. The spec uses `TracerProvider`s, which manage `Tracer`s,
+    # but which have internal methods and entities like `trace_id` and `TraceState`
+    # and `TraceFlags`. Then this library was initially written, I opted for uniformly
+    # consistent naming, but that violates the spec. Future versions will move towards
+    # deprecating the uniform naming, in places where that naming violates the spec.
+    # This is here to start preparing for that transition.
+    def tracer(
+      service_name = nil,
+      service_version = nil,
+      schema_url = nil,
+      exporter = nil,
+      provider = self
+    )
+      trace(service_name, service_version, schema_url, exporter, provider)
+    end
+
+    # Create a new, uninitialized trace, and pass it to the provided block to
+    # complete its initialization.
     def trace
       new_trace = trace
       new_trace.provider = self
@@ -29,5 +48,27 @@ module OpenTelemetry
 
       new_trace
     end
+
+    # Alias. The spec uses `TracerProvider`s, which manage `Tracer`s,
+    # but which have internal methods and entities like `trace_id` and `TraceState`
+    # and `TraceFlags`. Then this library was initially written, I opted for uniformly
+    # consistent naming, but that violates the spec. Future versions will move towards
+    # deprecating the uniform naming, in places where that naming violates the spec.
+    # This is here to start preparing for that transition.
+    def tracer
+      new_trace = trace
+      new_trace.provider = self
+      yield new_trace
+
+      new_trace
+    end
   end
+
+  # Alias. The spec uses `TracerProvider`s, which manage `Tracer`s,
+  # but which have internal methods and entities like `trace_id` and `TraceState`
+  # and `TraceFlags`. Then this library was initially written, I opted for uniformly
+  # consistent naming, but that violates the spec. Future versions will move towards
+  # deprecating the uniform naming, in places where that naming violates the spec.
+  # This is here to start preparing for that transition.
+  alias TracerProvider = TraceProvider
 end


### PR DESCRIPTION
This is a start to issue #3 . It just provides some aliases, with absolutely equivalent functionality, so that code can start shifting to the spec-compliant naming without breaking anything yet.