### PR TITLE
Update README with current state of initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The most common pattern for usage is to have a single global `TracerProvider` th
 OpenTelemetry.configure do |config|
   config.service_name = "my_app_or_library"
   config.service_version = "1.1.1"
-  config.exporter = OpenTelemetry::IOExporter.new(:STDOUT)
+  config.exporter = OpenTelemetry::Exporter.new(variant: :stdout)
 end
 ```
 
@@ -69,14 +69,14 @@ This allows multiple providers with different configuration to be created:
 
 ```crystal
 provider_a = OpenTelemetry::TracerProvider.new("my_app_or_library", "1.1.1")
-provider_a.exporter = OpenTelemetry::IOExporter.new(:STDOUT)
+provider_a.exporter = OpenTelemetry::Exporter.new(variant: :stdout)
 ```
 
 ```crystal
 provider_b = OpenTelementry::TracerProvider.new do |config|
   config.service_name = "my_app_or_library"
   config.service_version = "1.1.1"
-  config.exporter = OpenTelemetry::IOExporter.new(:STDOUT)
+  config.exporter = OpenTelemetry::Exporter.new(variant: :stdout)
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A lot of documentation needs to be added. PRs would be welcome!
 
    ```yaml
    dependencies:
-     otel:
+     opentelemetry-api:
        github: wyhaines/opentelemetry-api.cr
    ```
 

--- a/src/opentelemetry-api.cr
+++ b/src/opentelemetry-api.cr
@@ -22,7 +22,7 @@ require "random/pcg32"
 # OpenTelemetry.configure do |config|
 #   config.service_name = "my_app_or_library"
 #   config.service_version = "1.1.1"
-#   config.exporter = OpenTelemetry::IOExporter.new(:STDOUT)
+#   config.exporter = OpenTelemetry::Exporter.new(variant: :stdout)
 # end
 #
 # trace = OpenTelemetry.trace_provider("my_app_or_library", "1.1.1")
@@ -35,12 +35,12 @@ require "random/pcg32"
 # ----------------------------------------------------------------
 #
 # provider_a = OpenTelemetry::TraceProvider.new("my_app_or_library", "1.1.1")
-# provider_a.exporter = OpenTelemetry::IOExporter.new(:STDOUT)
+# provider_a.exporter = OpenTelemetry::Exporter.new(variant: :stdout)
 #
 # provider_b = OpenTelementry::TraceProvider.new do |config|
 #   config.service_name = "my_app_or_library"
 #   config.service_version = "1.1.1"
-#   config.exporter = OpenTelemetry::IOExporter.new(:STDOUT)
+#   config.exporter = OpenTelemetry::Exporter.new(variant: :stdout)
 # end
 #
 # ## Getting a Trace From a Provider Object

--- a/src/opentelemetry-api.cr
+++ b/src/opentelemetry-api.cr
@@ -25,7 +25,7 @@ require "random/pcg32"
 #   config.exporter = OpenTelemetry::Exporter.new(variant: :stdout)
 # end
 #
-# trace = OpenTelemetry.trace_provider("my_app_or_library", "1.1.1")
+# trace = OpenTelemetry.trace_provider("my_app_or_library", "1.1.1").trace
 # trace = OpenTelemetry.trace_provider do |provider|
 #   provider.service_name = "my_app_or_library"
 #   provider.service_version = "1.1.1"


### PR DESCRIPTION
1. Example from README.md for `shards.yml` ended with error message:

```
Error shard name (opentelemetry-api) doesn't match dependency name (otel)
```

2. Exporter initialization is different in readme from current state:

```
 16 | config.exporter = OpenTelemetry::IOExporter.new(:STDOUT)
                        ^------------------------
Error: undefined constant OpenTelemetry::IOExporter
```