### PR TITLE
Update type mismatch to Exporter::HTTP for endpoint

### DIFF
--- a/spec/exporters/http_spec.cr
+++ b/spec/exporters/http_spec.cr
@@ -1,0 +1,7 @@
+require "../spec_helper"
+
+describe OpenTelemetry::Exporter::Http do
+  it "initialize with endpoint argument" do
+    OpenTelemetry::Exporter::Http.new(endpoint: "http://localhost:4318/v1/traces")
+  end
+end

--- a/src/exporters/http.cr
+++ b/src/exporters/http.cr
@@ -26,10 +26,10 @@ module OpenTelemetry
       property clients : DB::Pool(HTTP::Client)
       @clients_are_initialized : Bool = false
       property headers : HTTP::Headers = HTTP::Headers.new
-      property endpoint_uri : URI = normalized_traces_endpoint_uri(URI.parse(
+      property endpoint_uri : URI = normalized_traces_endpoint_uri(
         ENV["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"]? ||
         ENV["OTEL_EXPORTER_OTLP_ENDPOINT"]? ||
-        "http://localhost:4318"))
+        "http://localhost:4318")
 
       def initialize(endpoint : String? = nil, _headers : HTTP::Headers? = nil, _clients : DB::Pool(HTTP::Client)? = nil, *_junk, **_kwjunk)
         @endpoint_uri = self.class.normalized_traces_endpoint_uri(endpoint) if endpoint
@@ -68,8 +68,11 @@ module OpenTelemetry
       end
 
       # TODO: Once we support more than just traces, how this all works will have to be revised.
-      private def self.normalized_traces_endpoint_uri(endpoint_uri)
-        endpoint_uri.to_s.ends_with?("traces") ? endpoint_uri : URI.parse(Path.new(endpoint_uri.to_s).join("/v1/traces").to_s)
+      def self.normalized_traces_endpoint_uri(endpoint : String) : URI
+        if !endpoint.to_s.ends_with?("traces")
+          endpoint = Path.new(endpoint.to_s).join("/v1/traces").to_s
+        end
+        URI.parse(endpoint)
       end
 
       # For other HTTP based protocols, such as gRPC, this method should be


### PR DESCRIPTION
Expoter::HTTP uses private methods to initialize @endpoint_uri and also works
difrently in case argument `endpoint` is String.

Add a sample tests to cover initialization part.

I see the code changed to support OTLP HTTP endpoint. Should it be extracted to separate Exporter and called "otlp-http"?