### PR TITLE
Extract gtihub pages deployment to separate workflow

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,11 +1,9 @@
-name: OpenTelemetry CI
+name: OpenTelemetry Build Docs
 
 on:
   schedule:
     - cron:  '0 3 * * *'
   push:
-    branches: [ main ]
-  pull_request:
     branches: [ main ]
 
 jobs:
@@ -19,11 +17,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: shards install
-    - name: Run tests
-      run: crystal spec -t -s
-    - name: Linting
-      run: crystal tool format --check
-    - name: Run Ameba
-      run: bin/ameba
     - name: Build docs
       run: crystal docs
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs

--- a/src/opentelemetry-api/propagation/trace_context/trace_parent.cr
+++ b/src/opentelemetry-api/propagation/trace_context/trace_parent.cr
@@ -2,7 +2,6 @@ module OpenTelemetry
   module Propagation
     struct TraceContext < TextMapPropagator
       struct TraceParent
-
         class InvalidFormatError < ArgumentError
           def initialize(format)
             super("Invalid TraceParent Format: #{format} lacks a recognizeable version, trace id, span id, or trace flags.")


### PR DESCRIPTION
Currently every PR triggeres deployment of docs.
Because there is no permissions to update gh-pages for contributors,
extract it to separate pipeline and triggers only on push to master.
Intorduce Linter to check if code formatted.