### PR TITLE
Handle the missing tracerparent from HTTP headers for extractor

### DIFF
--- a/spec/trace_context_spec.cr
+++ b/spec/trace_context_spec.cr
@@ -40,6 +40,18 @@ describe OpenTelemetry::Propagation::TraceContext do
     trace_context.trace_flags.should eq 0x01
   end
 
+  describe "#extract" do
+    it "skips extract trace context if missing HTTP::Header" do
+      headers = HTTP::Headers{
+        "Accept"     => "*/*",
+        "Host"       => "127.0.0.1:8080",
+        "User-Agent" => "curl/7.79.1",
+      }
+      subject = OpenTelemetry::Propagation::TraceContext.new.extract(headers)
+      subject.should be_nil
+    end
+  end
+
   it "can inject TraceContext into an object such as HTTP::Headers" do
     provider = OpenTelemetry::TraceProvider.new(
       service_name: "my_app_or_library",

--- a/src/opentelemetry-api/propagation/trace_context.cr
+++ b/src/opentelemetry-api/propagation/trace_context.cr
@@ -48,7 +48,7 @@ module OpenTelemetry
         end
 
         trace_parent_value = getter.get(carrier, TRACEPARENT_KEY)
-        return unless trace_parent_value
+        return if trace_parent_value.nil? || trace_parent_value.size == 0
 
         tp = TraceParent.from_string(trace_parent_value)
         ts = {} of String => String


### PR DESCRIPTION
Handle the case when carrier does not have required W3C key.

Currently if missing http header it generates exception:

```crystal
OpenTelemetry::Propagation::TraceContext.new(root_span.context).extract(request.headers).not_nil!
```

Produces error:

```

Index out of bounds (IndexError)
  from /opt/homebrew/Cellar/crystal/1.4.1/src/indexable.cr:73:20 in '[]'
  from lib/opentelemetry-api/src/opentelemetry-api/propagation/trace_context/trace_parent.cr:65:32 in 'initialize'
  from lib/opentelemetry-api/src/opentelemetry-api/propagation/trace_context/trace_parent.cr:63:9 in 'new'
  from lib/opentelemetry-api/src/opentelemetry-api/propagation/trace_context/trace_parent.cr:60:11 in 'from_string'
  from lib/opentelemetry-api/src/opentelemetry-api/propagation/trace_context.cr:56:14 in 'extract'
```