### PR TITLE
Propagator trace context extract to update trace_id from headers

### DIFF
--- a/spec/trace_context_spec.cr
+++ b/spec/trace_context_spec.cr
@@ -50,6 +50,19 @@ describe OpenTelemetry::Propagation::TraceContext do
       subject = OpenTelemetry::Propagation::TraceContext.new.extract(headers)
       subject.should be_nil
     end
+
+    it "returns span context with trace_id and span_id" do
+      headers = HTTP::Headers{
+        "Accept"      => "*/*",
+        "Host"        => "127.0.0.1:8080",
+        "User-Agent"  => "curl/7.79.1",
+        "Traceparent" => "00-1000000000000000209b117028ae242e-209b117028ae242e-01",
+        "baggage"     => "key1=,key2=val2",
+      }
+      subject = OpenTelemetry::Propagation::TraceContext.new.extract(headers).not_nil!
+      subject.trace_id.should eq Bytes[16, 0, 0, 0, 0, 0, 0, 0, 32, 155, 17, 112, 40, 174, 36, 46]
+      subject.span_id.should eq Bytes[32, 155, 17, 112, 40, 174, 36, 46]
+    end
   end
 
   it "can inject TraceContext into an object such as HTTP::Headers" do

--- a/src/opentelemetry-api/propagation/trace_context.cr
+++ b/src/opentelemetry-api/propagation/trace_context.cr
@@ -42,11 +42,6 @@ module OpenTelemetry
       end
 
       def extract(carrier, context : Context? = nil, getter : TextMapGetter.class = TextMapGetter)
-        span = OpenTelemetry.current_span
-        if span
-          span_context = span.context
-        end
-
         trace_parent_value = getter.get(carrier, TRACEPARENT_KEY)
         return unless trace_parent_value.presence
 
@@ -59,19 +54,7 @@ module OpenTelemetry
           ts[k.to_s] = v.to_s
         end
 
-        target = context ? context : span_context
-        if target
-          ts.each do |key, value|
-            target[key] = value
-          end
-        end
-
-        if target.is_a?(SpanContext)
-          target.trace_id = tp.trace_id
-          target.span_id = tp.span_id
-        end
-
-        target
+        ::OpenTelemetry::SpanContext.new(tp.trace_id, tp.span_id, nil, tp.trace_flags, ts, true)
       end
 
       def fields


### PR DESCRIPTION
It is not clear how to use Context after propagation, as it does not have trace_id information
and could not create spancontext after.

here is an example how i could use:

```
def call(context) : Nil
  request = context.request
  tracer = OpenTelemetry.trace
  span_context = OpenTelemetry::Propagation::TraceContext.new.extract(request.headers)
  if span_context
    tracer.trace_id = span_context.trace_id
    tracer.span_context = span_context
  end

  tracer.in_span()....
```

The ideal would be

```
def call(context) : Nil
  request = context.request
  ot_context = OpenTelemetry::Propagation::TraceContext.new.extract(request.headers, context: OpenTelemetry::Context.current)
  OpenTelemetry::Context.with(context: ot_context) do
    OpenTelemetry.trace.in_span()....
  end
```

I have a little knowledge `OpenTelemetry::Context.with` and would like to have a help.